### PR TITLE
test Moo classes when Moose is loaded

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for namespace-autoclean
 
 {{$NEXT}}
+  - package with only ExtUtils::MakeMaker to ease installation on perl 5.6
 
 0.26      2015-06-07 02:53:17Z
   - mark all Mouse tests as TODO below perl 5.010, to enable installation

--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ copyright_year = 2009
 
 [@Author::ETHER]
 :version = 0.094
+installer = MakeMaker
 Authority.authority = cpan:FLORA
 Git::Tag.tag_format = %v%t
 AutoPrereqs.skips[0] = ^Moo

--- a/t/moo-with-moose.t
+++ b/t/moo-with-moose.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+use Test::Requires {
+  'Moose' => '()',
+};
+do 't/moo.t';
+die $@ if $@;

--- a/t/moo.t
+++ b/t/moo.t
@@ -2,13 +2,11 @@ use strict;
 use warnings;
 use Test::More 0.88;
 
+# see moo-with-moose.t
+use constant WITH_MOOSE => !!$INC{'Moose.pm'};
+
 # blech! but Test::Requires does a stringy eval, so this works...
 use Test::Requires { 'Moo' => '()', 'Moo::Role' => '()' };
-
-{
-  package Temp1;
-  use Moo;
-}
 
 my $buzz; BEGIN { $buzz = sub {}; }
 my $welp; BEGIN { $welp = sub {}; }
@@ -31,8 +29,12 @@ ok defined &Some::Class::bar,
   'Some::Class::bar created normally';
 ok defined &Some::Class::guff,
   'Some::Class::guff added via glob assignment';
-ok !defined &Some::Class::welp,
-  'Some::Class::welp foreign added via glob assignment was cleaned';
+{
+  local $TODO = 'not working if Moose loaded'
+    if WITH_MOOSE;
+  ok !defined &Some::Class::welp,
+    'Some::Class::welp foreign added via glob assignment was cleaned';
+}
 ok !defined &Some::Class::cluck,
   'Some::Class::cluck imported sub was cleaned';
 ok !defined &Some::Class::fileparse,
@@ -65,8 +67,11 @@ ok defined &Some::Role::bar,
   'Some::Role::bar created normally';
 ok defined &Some::Role::guff,
   'Some::Role::guff added via glob assignment';
-ok !defined &Some::Role::welp,
-  'Some::Role::welp foreign added via glob assignment was cleaned';
+{
+  local $TODO = 'not working if Moose loaded';
+  ok !defined &Some::Role::welp,
+    'Some::Role::welp foreign added via glob assignment was cleaned';
+}
 ok !defined &Some::Role::cluck,
   'Some::Role::cluck imported sub was cleaned';
 ok !defined &Some::Role::fileparse,
@@ -87,8 +92,12 @@ ok defined &Consuming::Class::bar,
   'Consuming::Class::bar created normally';
 ok defined &Consuming::Class::guff,
   'Consuming::Class::guff added via glob assignment';
-ok !defined &Consuming::Class::welp,
-  'Consuming::Class::welp foreign added via glob assignment was cleaned';
+{
+  local $TODO = 'not working if Moose loaded'
+    if WITH_MOOSE;
+  ok !defined &Consuming::Class::welp,
+    'Consuming::Class::welp foreign added via glob assignment was cleaned';
+}
 ok !defined &Consuming::Class::cluck,
   'Consuming::Class::cluck imported sub was cleaned';
 ok !defined &Consuming::Class::fileparse,
@@ -109,8 +118,12 @@ ok defined &Consuming::Class::InBegin::bar,
   'Consuming::Class::InBegin::bar created normally';
 ok defined &Consuming::Class::InBegin::guff,
   'Consuming::Class::InBegin::guff added via glob assignment';
-ok !defined &Consuming::Class::InBegin::welp,
-  'Consuming::Class::InBegin::welp foreign added via glob assignment was cleaned';
+{
+  local $TODO = 'not working if Moose loaded'
+    if WITH_MOOSE;
+  ok !defined &Consuming::Class::InBegin::welp,
+    'Consuming::Class::InBegin::welp foreign added via glob assignment was cleaned';
+}
 ok !defined &Consuming::Class::InBegin::cluck,
   'Consuming::Class::InBegin::cluck imported sub was cleaned';
 ok !defined &Consuming::Class::InBegin::fileparse,
@@ -120,6 +133,8 @@ ok defined &Consuming::Class::InBegin::CAT,
 ok defined &Consuming::Class::InBegin::DOG,
   'Consuming::Class::InBegin::DOG constant with other glob entry';
 
-is $INC{'Class/MOP/Class.pm'}, undef, 'Class::MOP not loaded';
+if (!WITH_MOOSE) {
+  is $INC{'Class/MOP/Class.pm'}, undef, 'Class::MOP not loaded';
+}
 
 done_testing;


### PR DESCRIPTION
This adds a failing test for how namespace::autoclean handles Moo classes when Moose has been loaded.

I'm not sure how we want to handle this yet.